### PR TITLE
fix(security): add session middleware and server-side auth protection

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -13,8 +13,9 @@ import comments from './routes/comments';
 import * as schema from './db/schema';
 import { calculateHNScore } from './lib/utils';
 import type { Env } from './lib/auth';
+import { sessionMiddleware, type AuthVariables } from './middleware/auth';
 
-const app = new Hono<{ Bindings: Env }>();
+const app = new Hono<{ Bindings: Env; Variables: AuthVariables }>();
 
 app.use('*', logger());
 app.use(
@@ -29,6 +30,14 @@ app.use(
     credentials: true,
   })
 );
+
+// Apply session middleware to routes that need user context
+// NOT to /api/auth/* (better-auth handles its own routes)
+app.use('/api/posts/*', sessionMiddleware);
+app.use('/api/comments/*', sessionMiddleware);
+app.use('/api/users/*', sessionMiddleware);
+app.use('/api/admin/*', sessionMiddleware);
+app.use('/api/sites/*', sessionMiddleware);
 
 app.route('/api/health', health);
 app.route('/api/auth', auth);

--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -105,6 +105,7 @@ export const createAuth = (env: Env) => {
         karma: {
           type: 'number',
           defaultValue: 0,
+          input: false,
         },
         about: {
           type: 'string',
@@ -113,10 +114,12 @@ export const createAuth = (env: Env) => {
         isAdmin: {
           type: 'boolean',
           defaultValue: false,
+          input: false,
         },
         isBanned: {
           type: 'boolean',
           defaultValue: false,
+          input: false,
         },
       },
     },

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -1,0 +1,147 @@
+import { Context, Next } from 'hono';
+import { drizzle } from 'drizzle-orm/d1';
+import { eq } from 'drizzle-orm';
+import { createAuth, type Env } from '../lib/auth';
+import * as schema from '../db/schema';
+
+export type AuthUser = {
+  id: string;
+  email: string;
+  emailVerified: boolean;
+  username: string;
+  karma: number;
+  isAdmin: boolean;
+  isBanned: boolean;
+};
+
+export type AuthVariables = {
+  user: AuthUser | null;
+};
+
+/**
+ * Session middleware - loads session and fresh user data from DB
+ * Attaches user to context (or null if unauthenticated)
+ * Does NOT block requests - just provides data
+ */
+export async function sessionMiddleware(
+  c: Context<{ Bindings: Env; Variables: AuthVariables }>,
+  next: Next
+) {
+  const auth = createAuth(c.env);
+  const session = await auth.api.getSession({ headers: c.req.raw.headers });
+
+  if (!session?.user) {
+    c.set('user', null);
+    return next();
+  }
+
+  // Fetch fresh user data from DB (isAdmin, isBanned may have changed)
+  const db = drizzle(c.env.DB, { schema });
+  const [dbUser] = await db
+    .select({
+      id: schema.users.id,
+      email: schema.users.email,
+      emailVerified: schema.users.emailVerified,
+      username: schema.users.username,
+      karma: schema.users.karma,
+      isAdmin: schema.users.isAdmin,
+      isBanned: schema.users.isBanned,
+    })
+    .from(schema.users)
+    .where(eq(schema.users.id, session.user.id))
+    .limit(1);
+
+  if (!dbUser) {
+    c.set('user', null);
+    return next();
+  }
+
+  c.set('user', {
+    id: dbUser.id,
+    email: dbUser.email,
+    emailVerified: dbUser.emailVerified ?? false,
+    username: dbUser.username,
+    karma: dbUser.karma ?? 0,
+    isAdmin: dbUser.isAdmin ?? false,
+    isBanned: dbUser.isBanned ?? false,
+  });
+
+  return next();
+}
+
+/**
+ * Middleware: Require authenticated user
+ * Returns 401 if not authenticated, 403 if banned
+ */
+export function requireAuth() {
+  return async (
+    c: Context<{ Bindings: Env; Variables: AuthVariables }>,
+    next: Next
+  ) => {
+    const user = c.get('user');
+
+    if (!user) {
+      return c.json({ error: 'No autenticado' }, 401);
+    }
+
+    if (user.isBanned) {
+      return c.json({ error: 'Tu cuenta ha sido suspendida' }, 403);
+    }
+
+    return next();
+  };
+}
+
+/**
+ * Middleware: Require verified email
+ * Returns 401 if not authenticated, 403 if banned or email not verified
+ */
+export function requireVerifiedEmail() {
+  return async (
+    c: Context<{ Bindings: Env; Variables: AuthVariables }>,
+    next: Next
+  ) => {
+    const user = c.get('user');
+
+    if (!user) {
+      return c.json({ error: 'No autenticado' }, 401);
+    }
+
+    if (user.isBanned) {
+      return c.json({ error: 'Tu cuenta ha sido suspendida' }, 403);
+    }
+
+    if (!user.emailVerified) {
+      return c.json({ error: 'Debes verificar tu email' }, 403);
+    }
+
+    return next();
+  };
+}
+
+/**
+ * Middleware: Require admin privileges
+ * Returns 401 if not authenticated, 403 if banned or not admin
+ */
+export function requireAdmin() {
+  return async (
+    c: Context<{ Bindings: Env; Variables: AuthVariables }>,
+    next: Next
+  ) => {
+    const user = c.get('user');
+
+    if (!user) {
+      return c.json({ error: 'No autenticado' }, 401);
+    }
+
+    if (user.isBanned) {
+      return c.json({ error: 'Tu cuenta ha sido suspendida' }, 403);
+    }
+
+    if (!user.isAdmin) {
+      return c.json({ error: 'No autorizado' }, 403);
+    }
+
+    return next();
+  };
+}

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -11,6 +11,7 @@ database_id = "local"
 
 [vars]
 ENVIRONMENT = "development"
+FRONTEND_URL = "http://localhost:5173"
 
 # ============================================
 # Production environment

--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -1,5 +1,22 @@
 declare global {
-  namespace App {}
+  namespace App {
+    interface Locals {
+      user: {
+        id: string;
+        email: string;
+        name: string;
+        image: string | null;
+        emailVerified: boolean;
+        createdAt: string;
+        updatedAt: string;
+        username: string;
+        karma: number;
+        about: string | null;
+        isAdmin: boolean;
+        isBanned: boolean;
+      } | null;
+    }
+  }
 }
 
 export {};

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -1,0 +1,29 @@
+import type { Handle } from '@sveltejs/kit';
+import { PUBLIC_API_URL } from '$env/static/public';
+
+export const handle: Handle = async ({ event, resolve }) => {
+  const cookieHeader = event.request.headers.get('cookie');
+
+  if (cookieHeader) {
+    try {
+      // Forward cookies to API - better-auth validates the session token
+      // using BETTER_AUTH_SECRET on the backend
+      const response = await fetch(`${PUBLIC_API_URL}/api/auth/get-session`, {
+        headers: { cookie: cookieHeader },
+        credentials: 'include',
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        if (data.user) {
+          event.locals.user = data.user;
+        }
+      }
+    } catch (error) {
+      console.error('Session fetch error:', error);
+    }
+  }
+
+  event.locals.user = event.locals.user ?? null;
+  return resolve(event);
+};

--- a/web/src/lib/components/Header.svelte
+++ b/web/src/lib/components/Header.svelte
@@ -4,9 +4,16 @@
   import { page } from '$app/stores';
   import Logo from './Logo.svelte';
 
+  // Server-side loaded user (for initial render without flash)
+  let { user: serverUser }: { user: CustomUser | null } = $props();
+
+  // Client-side session (for real-time updates after login/logout)
   const session = useSession();
 
-  const user = $derived($session.data?.user as CustomUser | undefined);
+  // Prefer client session if available and not pending, otherwise use server data
+  const user = $derived(
+    $session.isPending ? serverUser : ($session.data?.user as CustomUser | undefined) ?? serverUser
+  );
   const pathname = $derived($page.url.pathname);
 
   let dropdownOpen = $state(false);
@@ -63,7 +70,7 @@
   </div>
 
   <div class="flex items-center">
-    {#if !$session.isPending && user}
+    {#if user}
       <!-- Desktop: links horizontales -->
       <div class="hidden md:flex items-center space-x-3">
         {#if pathname !== '/submit'}
@@ -127,7 +134,7 @@
           </div>
         {/if}
       </div>
-    {:else if !$session.isPending && !user && pathname !== '/login' && pathname !== '/register'}
+    {:else if !user && pathname !== '/login' && pathname !== '/register'}
       <a
         href="/login"
         class="text-neutral-700 px-3 py-1 rounded-full text-sm font-medium border border-neutral-300 hover:border-the-black hover:text-the-black transition-colors"

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -1,0 +1,7 @@
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ locals }) => {
+  return {
+    user: locals.user,
+  };
+};

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -4,11 +4,11 @@
   import Toast from '$lib/components/Toast.svelte';
   import KeyboardNav from '$lib/components/KeyboardNav.svelte';
 
-  let { children } = $props();
+  let { children, data } = $props();
 </script>
 
 <div class="min-h-screen p-2 sm:p-3 bg-the-white flex flex-col">
-  <Header />
+  <Header user={data.user} />
   {@render children()}
 </div>
 

--- a/web/src/routes/admin/+page.server.ts
+++ b/web/src/routes/admin/+page.server.ts
@@ -1,0 +1,16 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ locals }) => {
+  if (!locals.user) {
+    throw redirect(303, '/login');
+  }
+
+  if (!locals.user.isAdmin) {
+    throw redirect(303, '/');
+  }
+
+  return {
+    user: locals.user,
+  };
+};

--- a/web/src/routes/admin/+page.svelte
+++ b/web/src/routes/admin/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { useSession, type CustomUser } from '$lib/auth';
   import {
     getAdminStats,
     getAdminUsers,
@@ -17,8 +16,9 @@
     type AdminPost,
   } from '$lib/admin';
 
-  const session = useSession();
-  const user = $derived($session.data?.user as CustomUser | undefined);
+  // User is guaranteed to be admin by server-side load (redirects if not)
+  let { data } = $props();
+  const user = data.user!;
 
   let activeTab = $state<'stats' | 'users' | 'posts'>('stats');
   let stats = $state<AdminStats | null>(null);
@@ -80,17 +80,7 @@
   }
 
   onMount(() => {
-    if (user && !user.isAdmin) {
-      goto('/');
-    } else {
-      loadData();
-    }
-  });
-
-  $effect(() => {
-    if (!$session.isPending && user && !user.isAdmin) {
-      goto('/');
-    }
+    loadData();
   });
 </script>
 

--- a/web/src/routes/submit/+page.server.ts
+++ b/web/src/routes/submit/+page.server.ts
@@ -1,0 +1,16 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ locals }) => {
+  if (!locals.user) {
+    throw redirect(303, '/login');
+  }
+
+  if (locals.user.isBanned) {
+    throw redirect(303, '/?error=banned');
+  }
+
+  return {
+    user: locals.user,
+  };
+};

--- a/web/src/routes/submit/+page.svelte
+++ b/web/src/routes/submit/+page.svelte
@@ -1,29 +1,22 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { requireAuth } from '$lib/guards/requireAuth';
   import { createPost } from '$lib/posts';
   import { ApiError } from '$lib/api';
-  import { useSession, type CustomUser } from '$lib/auth';
   import PostPreviewCard from '$lib/components/PostPreviewCard.svelte';
   import { toast } from '$lib/toast';
   import { logoStore } from '$lib/stores/logo';
   import { draftStore } from '$lib/stores/drafts';
 
-  const session = useSession();
-  const user = $derived($session.data?.user as CustomUser | undefined);
-
-  let authorized = $state(false);
-  let checking = $state(true);
+  // User is guaranteed by server-side load (redirects if not logged in)
+  let { data } = $props();
+  const user = data.user!;
 
   let title = $state('');
   let url = $state('');
   let loading = $state(false);
 
-  onMount(async () => {
-    authorized = await requireAuth();
-    checking = false;
-
+  onMount(() => {
     const draft = draftStore.load();
     if (draft) {
       title = draft.title;
@@ -96,102 +89,96 @@
   <title>Publicar - the stack</title>
 </svelte:head>
 
-{#if checking}
-  <div class="flex-1 flex items-center justify-center">
-    <p class="text-neutral-500">Verificando autenticación...</p>
-  </div>
-{:else if authorized}
-  <div class="flex-1 flex items-center justify-center py-4 sm:py-0">
-    <div class="max-w-md w-full space-y-6 sm:space-y-8 px-4">
-      <div>
-        <h2 class="text-center text-2xl sm:text-3xl text-neutral-900">
-          Publicar en <span class="font-extrabold text-the-black">the stack</span>
-        </h2>
-      </div>
+<div class="flex-1 flex items-center justify-center py-4 sm:py-0">
+  <div class="max-w-md w-full space-y-6 sm:space-y-8 px-4">
+    <div>
+      <h2 class="text-center text-2xl sm:text-3xl text-neutral-900">
+        Publicar en <span class="font-extrabold text-the-black">the stack</span>
+      </h2>
+    </div>
 
-      <div class="space-y-4">
-        <form onsubmit={handleSubmit} class="space-y-3">
-          <div>
-            <label for="title" class="block text-sm font-medium text-neutral-700 mb-1">
-              Título
-            </label>
-            <input
-              type="text"
-              id="title"
-              bind:value={title}
-              required
-              maxlength={300}
-              disabled={loading}
-              class="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-1 focus:ring-the-black disabled:bg-neutral-100"
-              placeholder="Ingresa el título del artículo"
-            />
-          </div>
-
-          <div>
-            <label for="url" class="block text-sm font-medium text-neutral-700 mb-1">
-              URL
-            </label>
-            <input
-              type="url"
-              id="url"
-              bind:value={url}
-              required
-              disabled={loading}
-              class="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-1 focus:ring-the-black disabled:bg-neutral-100"
-              placeholder="https://ejemplo.com/articulo"
-            />
-          </div>
-
-          <button
-            type="submit"
+    <div class="space-y-4">
+      <form onsubmit={handleSubmit} class="space-y-3">
+        <div>
+          <label for="title" class="block text-sm font-medium text-neutral-700 mb-1">
+            Título
+          </label>
+          <input
+            type="text"
+            id="title"
+            bind:value={title}
+            required
+            maxlength={300}
             disabled={loading}
-            class="hover:cursor-pointer w-full hover:bg-the-white hover:text-the-black hover:ring-the-black hover:ring-1 text-white py-2 px-4 rounded-lg bg-the-black transition-colors disabled:bg-neutral-400 flex items-center justify-center gap-2"
-          >
-            {#if loading}
-              <span class="inline-block w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></span>
-              Publicando...
-            {:else}
-              Publicar
-            {/if}
-          </button>
-
-          <div class="text-center">
-            <a href="/" class="text-sm text-neutral-500 hover:text-neutral-700">
-              volver
-            </a>
-          </div>
-        </form>
-
-        <div class="space-y-2">
-          <div class="flex items-center gap-2">
-            <p class="text-sm text-neutral-500">Vista previa</p>
-            <svg
-              class="w-4 h-4 text-neutral-500"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-              />
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-              />
-            </svg>
-          </div>
-          <PostPreviewCard
-            {title}
-            {url}
-            username={user?.username || user?.name || ''}
+            class="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-1 focus:ring-the-black disabled:bg-neutral-100"
+            placeholder="Ingresa el título del artículo"
           />
         </div>
+
+        <div>
+          <label for="url" class="block text-sm font-medium text-neutral-700 mb-1">
+            URL
+          </label>
+          <input
+            type="url"
+            id="url"
+            bind:value={url}
+            required
+            disabled={loading}
+            class="w-full px-3 py-2 border border-neutral-300 rounded-lg focus:outline-none focus:ring-1 focus:ring-the-black disabled:bg-neutral-100"
+            placeholder="https://ejemplo.com/articulo"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading}
+          class="hover:cursor-pointer w-full hover:bg-the-white hover:text-the-black hover:ring-the-black hover:ring-1 text-white py-2 px-4 rounded-lg bg-the-black transition-colors disabled:bg-neutral-400 flex items-center justify-center gap-2"
+        >
+          {#if loading}
+            <span class="inline-block w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></span>
+            Publicando...
+          {:else}
+            Publicar
+          {/if}
+        </button>
+
+        <div class="text-center">
+          <a href="/" class="text-sm text-neutral-500 hover:text-neutral-700">
+            volver
+          </a>
+        </div>
+      </form>
+
+      <div class="space-y-2">
+        <div class="flex items-center gap-2">
+          <p class="text-sm text-neutral-500">Vista previa</p>
+          <svg
+            class="w-4 h-4 text-neutral-500"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+            />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+            />
+          </svg>
+        </div>
+        <PostPreviewCard
+          {title}
+          {url}
+          username={user.username || user.name || ''}
+        />
       </div>
     </div>
   </div>
-{/if}
+</div>


### PR DESCRIPTION
## Summary

- **Fix privilege escalation vulnerability**: Added `input: false` to `isAdmin`, `isBanned`, and `karma` fields in better-auth config to prevent attackers from setting these during signup
- **Centralized auth middleware**: New `sessionMiddleware` fetches fresh user data from DB on every request, ensuring ban enforcement works immediately
- **Server-side route protection**: Added `+page.server.ts` loaders to `/submit` and `/admin` routes (redirects before HTML is sent, no UI flash)
- **Hybrid session handling**: Header uses server-loaded user for initial render, client session for real-time updates after login/logout

## Security Improvements

| Before | After |
|--------|-------|
| Users could register with `isAdmin: true` | `input: false` blocks privilege escalation |
| Banned users could act until session expired | Fresh DB lookup on every API request |
| No ban check on API routes | All protected routes enforce ban status |
| Client-side redirects (UI flash, bypassable) | Server-side redirects in `+page.server.ts` |

## Test plan

- [ ] Try registering a new user and verify they cannot set `isAdmin`, `isBanned`, or `karma`
- [ ] Ban a user and verify they are immediately blocked from API actions
- [ ] Access `/admin` as non-admin and verify server-side redirect (no flash)
- [ ] Access `/submit` while logged out and verify redirect to `/login`
- [ ] Verify Header shows user info without flash on page load